### PR TITLE
Rename icons to RDNN to export them on Flatpak

### DIFF
--- a/data/com.github.libredeb.hashit.desktop.in
+++ b/data/com.github.libredeb.hashit.desktop.in
@@ -7,7 +7,7 @@ Comment=Intuitive and simple Hash Checker Tool
 GenericName=Hash Checker
 
 Exec=com.github.libredeb.hashit
-Icon=hashit
+Icon=com.github.libredeb.hashit
 Keywords=hash;check;sum;md5;sha256;
 Terminal=false
 Categories=GNOME;GTK;Utility;

--- a/meson.build
+++ b/meson.build
@@ -77,10 +77,12 @@ icon_sizes = ['16', '24', '32', '48', '64', '128']
 foreach i : icon_sizes
     install_data(
         join_paths('data', 'icons', i, 'hashit.svg'),
+        rename: meson.project_name() + '.svg',
         install_dir: join_paths(datadir, 'icons', 'hicolor', i + 'x' + i, 'apps')
     )
     install_data(
         join_paths('data', 'icons', i, 'hashit.svg'),
+        rename: meson.project_name() + '.svg',
         install_dir: join_paths(datadir, 'icons', 'hicolor', i + 'x' + i + '@2', 'apps')
     )
 endforeach

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -567,7 +567,7 @@ namespace Hashit {
 
         public App () {
             Object (
-                application_id: "com.github.libredeb.hashit",
+                application_id: Constants.APP_ID,
                 flags: GLib.ApplicationFlags.HANDLES_OPEN
             );
         }

--- a/src/Constants.vala
+++ b/src/Constants.vala
@@ -7,5 +7,6 @@
 namespace Constants {
    public const string PROGRAM_NAME = "Hash-it";
    public const string EXEC_NAME = "hashit";
+   public const string APP_ID = "com.github.libredeb.hashit";
    public const string APP_YEARS = "2016-2025";
 }

--- a/src/Widgets/AboutDialog.vala
+++ b/src/Widgets/AboutDialog.vala
@@ -14,7 +14,7 @@ namespace Hashit.Widgets {
         about.set_program_name (Constants.PROGRAM_NAME);
         about.set_version (Config.PACKAGE_VERSION);
         about.set_copyright (Constants.APP_YEARS);
-        about.set_logo_icon_name (Constants.EXEC_NAME);
+        about.set_logo_icon_name (Constants.APP_ID);
         about.set_license ("GPL v3");
         about.set_license_type (Gtk.License.GPL_3_0);
         about.set_comments (_("The most intuitive and simple hash tool checker"));


### PR DESCRIPTION
This fixes your app icons not exported and thus missing on Flatpak builds, as the stdout of flatpak-builder says:

```
Not exporting share/icons/hicolor/48x48@2/apps/hashit.svg, non-allowed export filename
Not exporting share/icons/hicolor/32x32/apps/hashit.svg, non-allowed export filename
Not exporting share/icons/hicolor/24x24/apps/hashit.svg, non-allowed export filename
Not exporting share/icons/hicolor/24x24@2/apps/hashit.svg, non-allowed export filename
Not exporting share/icons/hicolor/48x48/apps/hashit.svg, non-allowed export filename
Not exporting share/icons/hicolor/16x16@2/apps/hashit.svg, non-allowed export filename
Not exporting share/icons/hicolor/128x128/apps/hashit.svg, non-allowed export filename
Not exporting share/icons/hicolor/64x64/apps/hashit.svg, non-allowed export filename
Not exporting share/icons/hicolor/64x64@2/apps/hashit.svg, non-allowed export filename
Not exporting share/icons/hicolor/icon-theme.cache, wrong extension
Not exporting share/icons/hicolor/16x16/apps/hashit.svg, non-allowed export filename
Not exporting share/icons/hicolor/32x32@2/apps/hashit.svg, non-allowed export filename
Not exporting share/icons/hicolor/128x128@2/apps/hashit.svg, non-allowed export filename
```
