### PR TITLE
Use gresource for icons to avoid assuming fixed path

### DIFF
--- a/data/com.github.libredeb.hashit.gresource.xml
+++ b/data/com.github.libredeb.hashit.gresource.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/com/github/libredeb/hashit/icons">
+    <file compressed="true" preprocess="xml-stripblanks" alias="result-ok.svg">gfx/result-ok.svg</file>
+    <file compressed="true" preprocess="xml-stripblanks" alias="result-status.svg">gfx/result-status.svg</file>
+    <file compressed="true" preprocess="xml-stripblanks" alias="result-error.svg">gfx/result-error.svg</file>
+  </gresource>
+</gresources>

--- a/meson.build
+++ b/meson.build
@@ -38,6 +38,14 @@ config_dep = declare_dependency(
 
 config_inc_dir = include_directories('.')
 
+gnome = import('gnome')
+asresources = gnome.compile_resources(
+    'as-resources',
+    join_paths('data', meson.project_name() + '.gresource.xml'),
+    source_dir: 'data',
+    c_name: 'as'
+)
+
 ValaArgs = [
     '--pkg=config',
     '--vapidir=' + VAPI_DIR
@@ -46,6 +54,7 @@ ValaArgs = [
 # Create a new executable, list the files we want to compile, list the dependencies we need, and install
 executable(
     meson.project_name(),
+    asresources,
     'src/Widgets/InputView.vala',
     'src/Widgets/Selection.vala',
     'src/Widgets/AboutDialog.vala',

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -178,42 +178,12 @@ namespace Hashit {
             compare_button.set_margin_top (4);
 
             //Status Icons
-            this.result_status_img = new Image ();
+            this.result_status_img = new Image.from_icon_name ("result-status");
             this.result_status_img.add_css_class (Granite.STYLE_CLASS_LARGE_ICONS);
-            try {
-                var result_status_pixbuf = new Gdk.Pixbuf.from_file_at_scale (
-                    "/usr/share/hashit/gfx/result-status.svg", 24, 24, false
-                );
-                var result_status_texture = Gdk.Texture.for_pixbuf (result_status_pixbuf);
-                this.result_status_img.set_from_paintable (result_status_texture);
-            } catch (GLib.Error e) {
-                warning ("Error creating pixbuf icon for status image");
-                warning ("Check file /usr/share/hashit/gfx/result-status.svg");
-            }
-            Image result_ok_img = new Image ();
+            Image result_ok_img = new Image.from_icon_name ("result-ok");
             result_ok_img.add_css_class (Granite.STYLE_CLASS_LARGE_ICONS);
-            try {
-                var result_ok_pixbuf = new Gdk.Pixbuf.from_file_at_scale (
-                    "/usr/share/hashit/gfx/result-ok.svg", 24, 24, false
-                );
-                var result_ok_texture = Gdk.Texture.for_pixbuf (result_ok_pixbuf);
-                result_ok_img.set_from_paintable (result_ok_texture);
-            } catch (GLib.Error e) {
-                warning ("Error creating pixbuf icon for status_ok image");
-                warning ("Check file /usr/share/hashit/gfx/result-ok.svg");
-            }
-            Image result_error_img = new Image ();
+            Image result_error_img = new Image.from_icon_name ("result-error");
             result_error_img.add_css_class (Granite.STYLE_CLASS_LARGE_ICONS);
-            try {
-                var result_error_pixbuf = new Gdk.Pixbuf.from_file_at_scale (
-                    "/usr/share/hashit/gfx/result-error.svg", 24, 24, false
-                );
-                var result_error_texture = Gdk.Texture.for_pixbuf (result_error_pixbuf);
-                result_error_img.set_from_paintable (result_error_texture);
-            } catch (GLib.Error e) {
-                warning ("Error creating pixbuf icon for status_error image");
-                warning ("Check file /usr/share/hashit/gfx/result-error.svg");
-            }
 
             // Entrys
             last_hash_entry = new Entry ();


### PR DESCRIPTION
Your app assumes icons are installed under `/usr/share/hashit/gfx/`. This works for native builds but not for Flatpak builds, resulting your app always fails to load icons on Flatpak:

```
** (com.github.libredeb.hashit:2): WARNING **: 12:17:38.038: Application.vala:190: Error creating pixbuf icon for status image

** (com.github.libredeb.hashit:2): WARNING **: 12:17:38.038: Application.vala:191: Check file /usr/share/hashit/gfx/result-status.svg

** (com.github.libredeb.hashit:2): WARNING **: 12:17:38.038: Application.vala:202: Error creating pixbuf icon for status_ok image

** (com.github.libredeb.hashit:2): WARNING **: 12:17:38.038: Application.vala:203: Check file /usr/share/hashit/gfx/result-ok.svg

** (com.github.libredeb.hashit:2): WARNING **: 12:17:38.038: Application.vala:214: Error creating pixbuf icon for status_error image

** (com.github.libredeb.hashit:2): WARNING **: 12:17:38.038: Application.vala:215: Check file /usr/share/hashit/gfx/result-error.svg
```

This PR fixes this issue by using gresource to load icons.
