### PR TITLE
Fix crash when failed to open files

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -531,12 +531,20 @@ namespace Hashit {
         public void get_file_hash (string path) {
             this.files_uris.append_val (path);
 
-            string hash = Hashit.Backend.Checksum.calculate_hash (
+            string? hash = Hashit.Backend.Checksum.calculate_hash (
                 this.selection_box.get_dropdown_value (),
                 path
             );
 
             GLib.Idle.add (() => {
+                if (hash == null) {
+                    var toast = new Adw.Toast (_("Failed to calculate hash"));
+                    toast.set_timeout (2);
+                    this.toast_overlay.add_toast (toast);
+
+                    return false;
+                }
+
                 this.last_hash_entry.set_text (hash);
 
                 TextIter text_end_iter;

--- a/src/Backend/Checksum.vala
+++ b/src/Backend/Checksum.vala
@@ -5,7 +5,7 @@
 
 namespace Hashit.Backend.Checksum {
 
-    public static string calculate_hash (string type, string file_path) {
+    public static string? calculate_hash (string type, string file_path) {
         GLib.Checksum checksum = null;
 
         switch (type) {
@@ -23,7 +23,12 @@ namespace Hashit.Backend.Checksum {
                 break;
         }
 
-        FileStream stream = FileStream.open (file_path, "rb");
+        FileStream? stream = FileStream.open (file_path, "rb");
+        if (stream == null) {
+            warning ("Failed to open \"%s\": %s", file_path, strerror(errno));
+            return null;
+        }
+
         uint8 buffer[100];
         size_t size;
 


### PR DESCRIPTION
Fixes #2

The crash occurs because the app does not check errors when *fopen*ing  files to calculate a checksum is failed and causes a null access to FileStream. This PR make sure to perform an error check after fopen and plus tell users that calculation is failed.
